### PR TITLE
Several fixes for the open/save file behavior.

### DIFF
--- a/trunk/EditForm.cs
+++ b/trunk/EditForm.cs
@@ -55,6 +55,7 @@ namespace LSLEditor
 
         public List<string> verboseQueue = new List<string>();
 
+        private bool m_IsNew;
         private string m_FullPathName;
 		private Guid m_Guid;
 		// private bool sOutline = true;
@@ -239,6 +240,7 @@ namespace LSLEditor
 					if (!Directory.Exists(Properties.Settings.Default.WorkingDirectory)) {
 						Properties.Settings.Default.WorkingDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 					}
+					this.m_IsNew = true;
 					this.m_FullPathName = Path.Combine(Properties.Settings.Default.WorkingDirectory, this.m_FullPathName);
 				}
 				this.Text = this.ScriptName;
@@ -246,6 +248,14 @@ namespace LSLEditor
 				if (tabPage != null) {
 					tabPage.Text = this.Text + "   ";
 				}
+			}
+		}
+
+		public bool IsNew
+		{
+			get
+			{
+				return this.m_IsNew;
 			}
 		}
 
@@ -332,37 +342,7 @@ namespace LSLEditor
 		public void SaveCurrentFile(string strPath)
 		{
             // Check if this is an expanded.lsl
-            if (!LSLIPathHelper.IsExpandedLSL(strPath))
-            {
-                this.FullPathName = strPath;
-                Encoding encodeAs = this.encodedAs;
-                if (this.IsScript && encodeAs == null)
-                {
-                    switch (Properties.Settings.Default.OutputFormat)
-                    {
-                        case "UTF8":
-                            encodeAs = Encoding.UTF8;
-                            break;
-                        case "Unicode":
-                            encodeAs = Encoding.Unicode;
-                            break;
-                        case "BigEndianUnicode":
-                            encodeAs = Encoding.BigEndianUnicode;
-                            break;
-                        default:
-                            encodeAs = Encoding.Default;
-                            break;
-                    }
-                }
-                else if (encodeAs == null)
-                {
-                    encodeAs = Encoding.UTF8;
-                }
-
-                this.numberedTextBoxUC1.TextBox.SaveCurrentFile(strPath, encodeAs);
-                this.encodedAs = encodeAs;
-
-            } else if (LSLIPathHelper.IsExpandedLSL(strPath))
+            if (LSLIPathHelper.IsExpandedLSL(strPath))
             {
                 string LSLIfilePath = LSLIPathHelper.CreateCollapsedPathAndScriptName(strPath);
                 // Check if an LSLI version of this script exists
@@ -392,6 +372,37 @@ namespace LSLEditor
                 this.numberedTextBoxUC1.TextBox.Dirty = false;
                 this.Text = LSLIPathHelper.GetExpandedTabName(strPath);
             }
+            else
+            {
+                this.FullPathName = strPath;
+                Encoding encodeAs = this.encodedAs;
+                if (this.IsScript && encodeAs == null)
+                {
+                    switch (Properties.Settings.Default.OutputFormat)
+                    {
+                        case "UTF8":
+                            encodeAs = Encoding.UTF8;
+                            break;
+                        case "Unicode":
+                            encodeAs = Encoding.Unicode;
+                            break;
+                        case "BigEndianUnicode":
+                            encodeAs = Encoding.BigEndianUnicode;
+                            break;
+                        default:
+                            encodeAs = Encoding.Default;
+                            break;
+                    }
+                }
+                else if (encodeAs == null)
+                {
+                    encodeAs = Encoding.UTF8;
+                }
+
+                this.numberedTextBoxUC1.TextBox.SaveCurrentFile(strPath, encodeAs);
+                this.encodedAs = encodeAs;
+            }
+			this.m_IsNew = false;
         }
 
 		public void SaveCurrentFile()
@@ -542,6 +553,7 @@ namespace LSLEditor
 		private void EditForm_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			this.parent.CancelClosing = false;
+			this.parent.ActivateMdiForm(this);
 			if (this.Dirty) {
                 string scriptToSave = ScriptName;
                 if (LSLIPathHelper.IsExpandedLSL(ScriptName))

--- a/trunk/LSLEditorForm.cs
+++ b/trunk/LSLEditorForm.cs
@@ -378,9 +378,10 @@ namespace LSLEditor
 
 		private void NewNotecard()
 		{
+			string fullPathName = Properties.Settings.Default.ExampleNameNotecard;
 			EditForm editForm = new EditForm(this);
 			editForm.IsScript = false;
-			editForm.FullPathName = Properties.Settings.Default.ExampleNameNotecard;
+			editForm.FullPathName = fullPathName;
 			editForm.TextBox.OnCursorPositionChanged += new SyntaxRichTextBox.CursorPositionChangedHandler(TextBox_OnCursorPositionChanged);
 			editForm.Dirty = false;
 			AddForm(editForm);
@@ -388,45 +389,49 @@ namespace LSLEditor
 
 		private void NewFile(bool isLSLI = false)
 		{
+			string fullPathName = isLSLI ? Properties.Settings.Default.ExampleNameLSLI : Properties.Settings.Default.ExampleName;
 			EditForm editForm = new EditForm(this);
 			editForm.SourceCode = Helpers.GetTemplate.Source();
 			editForm.TextBox.FormatDocument();
 			editForm.TextBox.ClearUndoStack();
-            if(isLSLI)
-            {
-			    editForm.FullPathName = Properties.Settings.Default.ExampleNameLSLI;
-            } else
-            {
-                editForm.FullPathName = Properties.Settings.Default.ExampleName;
-            }
+			editForm.FullPathName = fullPathName;
             editForm.TextBox.OnCursorPositionChanged += new SyntaxRichTextBox.CursorPositionChangedHandler(TextBox_OnCursorPositionChanged);
+			editForm.Dirty = false;
 			AddForm(editForm);
 		}
 
 		public EditForm OpenFile(string strPath, Guid guid, bool blnIsScript)
 		{
 			EditForm editForm = null;
-			if (this.Children.Length > 0) {
-				editForm = this.Children[0] as EditForm;
-				if (editForm != null && !editForm.IsDisposed) {
-					if (editForm.ScriptName != Properties.Settings.Default.ExampleName || editForm.Dirty) {
-						editForm = null;
-					}
+
+			foreach (Form child in this.Children) {
+				EditForm form = child as EditForm;
+				if (form == null || form.IsDisposed || form.IsNew) {
+					continue;
+				}
+				if (form.FullPathName == strPath) {
+					editForm = form;
+					break;
 				}
 			}
 
 			if (editForm == null) {
 				editForm = new EditForm(this);
 				editForm.TextBox.OnCursorPositionChanged += new SyntaxRichTextBox.CursorPositionChangedHandler(TextBox_OnCursorPositionChanged);
+				editForm.guid = guid;
+				editForm.IsScript = blnIsScript;
+				editForm.LoadFile(strPath);
 				AddForm(editForm);
+				ActivateMdiForm(editForm);
+			} else if (editForm.Dirty) {
+				ActivateMdiForm(editForm);
+				DialogResult dialogResult = MessageBox.Show(@"Revert file """ + editForm.ScriptName + @""" to last saved state? Your changes will be lost!", "File has changed", MessageBoxButtons.OKCancel);
+				if (dialogResult == DialogResult.OK) {
+					editForm.LoadFile(strPath);
+					editForm.TextBox.ClearUndoStack();
+					editForm.Dirty = false;
+				}
 			}
-
-			editForm.guid = guid;
-			editForm.IsScript = blnIsScript;
-			editForm.LoadFile(strPath);
-
-			// 23 oct 2007
-			ActivateMdiForm(editForm);
 
 			UpdateRecentFileList(strPath);
 
@@ -445,7 +450,7 @@ namespace LSLEditor
 
 		private void OpenFile(string strFileName)
 		{
-			OpenFile(strFileName, Guid.Empty, true);
+			OpenFile(strFileName, Guid.NewGuid(), true);
 		}
 
 		private string ClippedPath(string strPath)
@@ -566,7 +571,6 @@ namespace LSLEditor
 				foreach (string strFileName in this.openNoteFilesDialog.FileNames) {
 					if (File.Exists(strFileName)) {
 						OpenFile(strFileName, Guid.NewGuid(), false);
-						UpdateRecentFileList(strFileName);
 					}
 				}
 			}
@@ -579,7 +583,6 @@ namespace LSLEditor
 				foreach (string strFileName in this.openScriptFilesDialog.FileNames) {
 					if (File.Exists(strFileName)) {
 						OpenFile(strFileName, Guid.NewGuid());
-						UpdateRecentFileList(strFileName);
 					}
 				}
 			}
@@ -597,8 +600,10 @@ namespace LSLEditor
 		public bool SaveFile(EditForm editForm, bool blnSaveAs)
 		{
 			DialogResult dialogresult = DialogResult.OK;
-			if (editForm.FullPathName == Properties.Settings.Default.ExampleName || blnSaveAs) {
-				SaveFileDialog saveDialog = editForm.IsScript ? this.saveScriptFilesDialog : this.saveNoteFilesDialog;
+			if (blnSaveAs || editForm.IsNew) {
+                ActivateMdiForm(editForm);
+
+                SaveFileDialog saveDialog = editForm.IsScript ? this.saveScriptFilesDialog : this.saveNoteFilesDialog;
 
                 // Save as LSLI when it's an expanded LSL
                 if (Helpers.LSLIPathHelper.IsExpandedLSL(editForm.ScriptName))
@@ -623,32 +628,22 @@ namespace LSLEditor
 			return false;
 		}
 
-		// save file of active MDI child, if any
-		private bool SaveActiveFile()
-		{
-			bool blnResult = false;
-			EditForm editForm = this.ActiveMdiForm as EditForm;
-			if (editForm != null) {
-				// save as!!
-				// TODO: Refactor saveDialog to be a property of the form
-				SaveFileDialog saveDialog = editForm.IsScript ? this.saveScriptFilesDialog : this.saveNoteFilesDialog;
-				blnResult = SaveFile(editForm, true);
-			}
-			return blnResult;
-		}
-
 		private void saveToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			EditForm editForm = this.ActiveMdiForm as EditForm;
 			if (editForm != null) {
-				editForm.SaveCurrentFile();
+				SaveFile(editForm, false);
 				this.Focus();
 			}
 		}
 
 		private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			SaveActiveFile();
+			EditForm editForm = this.ActiveMdiForm as EditForm;
+			if (editForm != null) {
+				SaveFile(editForm, true);
+				this.Focus();
+			}
 		}
 
 		private Browser GetBrowser()
@@ -1271,7 +1266,7 @@ namespace LSLEditor
 				}
 				if (Properties.Settings.Default.AutoSaveOnDebug) {
 					if (editForm.Dirty) {
-						editForm.SaveCurrentFile();
+						SaveFile(editForm, false);
 					}
 				}
 				editForm.SyntaxCheck();
@@ -1437,10 +1432,10 @@ namespace LSLEditor
 
 		public void CloseActiveWindow()
 		{
-            EditForm editForm = this.ActiveMdiForm as EditForm;
-            if (this.IsMdiContainer) {
-				if (this.ActiveMdiForm != null && !this.ActiveMdiForm.IsDisposed) {
-					this.ActiveMdiForm.Close();
+			if (this.IsMdiContainer) {
+				EditForm editForm = this.ActiveMdiForm as EditForm;
+				if (editForm != null && !editForm.IsDisposed) {
+					editForm.Close();
 				}
 			} else {
 				//TODO: Find a new way
@@ -1597,8 +1592,18 @@ namespace LSLEditor
 				this.fileStripMenuItem.HideDropDown();
 
 				string strPath = tsmi.Tag.ToString();
-				OpenFile(strPath, Guid.NewGuid());
-				UpdateRecentFileList(strPath);
+				if (!File.Exists(strPath)) {
+					DialogResult dialogResult = MessageBox.Show("File not found. Do you want to remove it from the recent list?", "File not found", MessageBoxButtons.YesNo);
+					if (dialogResult == DialogResult.Yes) {
+						this.recentFileToolStripMenuItem.DropDownItems.Remove(tsmi);
+						Properties.Settings.Default.RecentFileList.Remove(strPath);
+					}
+					return;
+				}
+
+				string strExt = Path.GetExtension(strPath);
+				bool blnIsScript = strExt == ".lsl" || strExt == ".lsli";
+				OpenFile(strPath, Guid.NewGuid(), blnIsScript);
 			}
 		}
 
@@ -1669,8 +1674,17 @@ namespace LSLEditor
 			if (tsmi != null) {
 				this.fileStripMenuItem.HideDropDown();
 
+				string strPath = tsmi.Tag.ToString();
+				if (!File.Exists(strPath)) {
+					DialogResult dialogResult = MessageBox.Show("Project not found. Do you want to remove it from the recent list?", "Project not found", MessageBoxButtons.YesNo);
+					if (dialogResult == DialogResult.Yes) {
+						this.recentProjectToolStripMenuItem.DropDownItems.Remove(tsmi);
+						Properties.Settings.Default.RecentProjectList.Remove(strPath);
+					}
+					return;
+				}
+
 				if (CloseAllOpenWindows()) {
-					string strPath = tsmi.Tag.ToString();
 					this.SolutionExplorer.OpenSolution(strPath);
 				}
 			}
@@ -1802,7 +1816,7 @@ namespace LSLEditor
 					continue;
 				}
 				if (editForm.Dirty) {
-					editForm.SaveCurrentFile();
+					SaveFile(editForm, false);
 				}
 			}
 			// save it all, also solution explorer file

--- a/trunk/LSLEditorForm.cs
+++ b/trunk/LSLEditorForm.cs
@@ -423,13 +423,15 @@ namespace LSLEditor
 				editForm.LoadFile(strPath);
 				AddForm(editForm);
 				ActivateMdiForm(editForm);
-			} else if (editForm.Dirty) {
+			} else {
 				ActivateMdiForm(editForm);
-				DialogResult dialogResult = MessageBox.Show(@"Revert file """ + editForm.ScriptName + @""" to last saved state? Your changes will be lost!", "File has changed", MessageBoxButtons.OKCancel);
-				if (dialogResult == DialogResult.OK) {
-					editForm.LoadFile(strPath);
-					editForm.TextBox.ClearUndoStack();
-					editForm.Dirty = false;
+				if (editForm.Dirty) {
+					DialogResult dialogResult = MessageBox.Show(@"Revert file """ + editForm.ScriptName + @""" to last saved state? Your changes will be lost!", "File has changed", MessageBoxButtons.OKCancel);
+					if (dialogResult == DialogResult.OK) {
+						editForm.LoadFile(strPath);
+						editForm.TextBox.ClearUndoStack();
+						editForm.Dirty = false;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix the dialog call to save a new file.
The Editor creates a new file by giving the name only.
Acknowledging that, add a tag to mark the file as new.

Fix not found recent file/project.

Fix the ability to open multiple times the same file.

Partial Fix to the detection of simple file when opening files.

Partial Fix to generate GUID when opening files.

Remove some of the duplicate calls to UpdateRecentFileList.